### PR TITLE
Data saved with the record button was saved uncalibrated

### DIFF
--- a/Unit1.cpp
+++ b/Unit1.cpp
@@ -3749,10 +3749,10 @@ void __fastcall TForm1::WMNewData(TMessage &msg)
 			if (CalibrationForm && data_unit.m_vna_data.type != UNIT_TYPE_TINYSA)
 				CalibrationForm->scanComplete(new_points);
 
-//			if (!settings.useVNACalibration && data_unit.m_vna_data.type != UNIT_TYPE_TINYSA)
-//				calibration.correct(calibration_module.m_calibration, points, true, true, true);	// use calibrations to correct
+			if (!settings.useVNACalibration && data_unit.m_vna_data.type != UNIT_TYPE_TINYSA)
+				calibration.correct(calibration_module.m_calibration, points, true, true, true);	// use calibrations to correct
 
-			recordDataToFile(new_points);	// stream the incoming (raw uncorrected) sparams to files
+			recordDataToFile(new_points);	// stream the incoming sparams to files
 		}
 
 		updateHistoryFramesInfo();

--- a/Unit1.cpp
+++ b/Unit1.cpp
@@ -3749,8 +3749,10 @@ void __fastcall TForm1::WMNewData(TMessage &msg)
 			if (CalibrationForm && data_unit.m_vna_data.type != UNIT_TYPE_TINYSA)
 				CalibrationForm->scanComplete(new_points);
 
-			if (!settings.useVNACalibration && data_unit.m_vna_data.type != UNIT_TYPE_TINYSA)
-				calibration.correct(calibration_module.m_calibration, points, true, true, true);	// use calibrations to correct
+			// Calibrate the points
+//			if (data_unit.m_vna_data.type != UNIT_TYPE_TINYSA)
+//				if (settings.calibrationSelection == CAL_SELECT_APP)
+//					calibration_module.correct(new_points);
 
 			recordDataToFile(new_points);	// stream the incoming sparams to files
 		}
@@ -4026,6 +4028,13 @@ void __fastcall TForm1::recordDataToFile(std::vector <t_data_point> &points)
 	if (size <= 0)
 		return;
 
+	std::vector <t_data_point> points_corrected = points;
+
+	// Calibrate the points
+	if (data_unit.m_vna_data.type != UNIT_TYPE_TINYSA)
+		if (settings.calibrationSelection == CAL_SELECT_APP)
+			calibration_module.correct(points_corrected);
+
 /*
 	int hist_index = (data_unit.m_history_frames > 0) ? data_unit.m_history_index - 1 : 0;
 	if (hist_index < 0)
@@ -4061,7 +4070,7 @@ void __fastcall TForm1::recordDataToFile(std::vector <t_data_point> &points)
 		filename += m_record.filename + "_";
 	filename += IntToStr(m_record.file_number) + ".s2p";
 
-	if (!common.saveSParams(points, 4, filename))
+	if (!common.saveSParams(points_corrected, 4, filename))
 	//if (!common.saveSParams(m_record.points, 4, filename))
 	{
 

--- a/Unit1.cpp
+++ b/Unit1.cpp
@@ -3749,10 +3749,8 @@ void __fastcall TForm1::WMNewData(TMessage &msg)
 			if (CalibrationForm && data_unit.m_vna_data.type != UNIT_TYPE_TINYSA)
 				CalibrationForm->scanComplete(new_points);
 
-			// Calibrate the points
-//			if (data_unit.m_vna_data.type != UNIT_TYPE_TINYSA)
-//				if (settings.calibrationSelection == CAL_SELECT_APP)
-//					calibration_module.correct(new_points);
+//			if (!settings.useVNACalibration && data_unit.m_vna_data.type != UNIT_TYPE_TINYSA)
+//				calibration.correct(calibration_module.m_calibration, points, true, true, true);	// use calibrations to correct
 
 			recordDataToFile(new_points);	// stream the incoming sparams to files
 		}


### PR DESCRIPTION
I'm not sure why this is, but it would seem that at some point in time, the record button's saving functionality stopped recording data calibrated by NanoVNA. I've uncommented it in this pull request.

Perhaps this could be a toggleable option? I wouldn't mind implementing it, I just don't want to go ahead and do that without the goahead.

Thanks